### PR TITLE
extend DW dockerfile, adjust templates to latest standard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-FROM buildkite/agent:alpine-docker-1.11
+FROM quay.io/democracyworks/buildkite-agent-coreos:2.6.5
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
-ENV FLEETCTL_VERSION 0.11.8
-
-# install openssl, jq and aws
-RUN pip install awscli
-RUN apk add --update --no-cache openssl jq
-
-# install fleetctl
-ADD https://github.com/coreos/fleet/releases/download/v${FLEETCTL_VERSION}/fleet-v${FLEETCTL_VERSION}-linux-amd64.tar.gz /tmp/fleet.tar.gz
-RUN tar -C /tmp -xzf /tmp/fleet.tar.gz && mv /tmp/fleet-v${FLEETCTL_VERSION}-linux-amd64/fleetctl /bin/ && \
-    rm -rf /tmp/fleet-v${FLEETCTL_VERSION}-linux-amd64 && rm /tmp/fleet.tar.gz
-
-COPY hooks /buildkite/hooks
+COPY hooks/environment /buildkite/hooks/environment

--- a/buildkite-agent-consul-production@.service.template
+++ b/buildkite-agent-consul-production@.service.template
@@ -25,10 +25,8 @@ ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \
   --env BUILDKITE_AGENT_TOKEN=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/agent-token?raw) \
   --env BUILDKITE_AGENT_META_DATA="coreos=true,environment=production" \
   --env DOCKERCFG=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/vip/dockercfg?raw)\" \
-  --env DOCKER_API_VERSION=\"$(docker version | grep "Server API version:" | awk \'{print $4}\')\" \
   --env SSH_PRIVATE_RSA_KEY=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/pem-file/production?raw)" \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume /opt/bin/docker.static:/usr/bin/docker \
   ${DOCKER_REPO}:${VERSION}'
 
 # USR2 will tell the agent to wrap up any currently-running builds and then shutdown

--- a/buildkite-agent-consul-staging@.service.template
+++ b/buildkite-agent-consul-staging@.service.template
@@ -25,10 +25,8 @@ ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \
   --env BUILDKITE_AGENT_TOKEN=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/agent-token?raw) \
   --env BUILDKITE_AGENT_META_DATA="coreos=true,environment=staging" \
   --env DOCKERCFG=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/vip/dockercfg?raw)\" \
-  --env DOCKER_API_VERSION=\"$(docker version | grep "Server API version:" | awk \'{print $4}\')\" \
   --env SSH_PRIVATE_RSA_KEY=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/pem-file/staging?raw)" \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume /opt/bin/docker.static:/usr/bin/docker \
   ${DOCKER_REPO}:${VERSION}'
 
 # USR2 will tell the agent to wrap up any currently-running builds and then shutdown


### PR DESCRIPTION
Rather than being a clone of the DW buildkite-agent-consul,
we can just extend it and add an extra step to copy our
specific hooks in place.

Then I just needed to adjust the docker run
commands like the DW one does to work with the
new coreos environment.