### PR TITLE
upgrade the buildkite agents to work with alexa deploy process and ol…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,35 @@
-FROM quay.io/democracyworks/buildkite-agent-coreos:2.6.5
-MAINTAINER Democracy Works, Inc. <dev@democracy.works>
+FROM buildkite/agent:3.5.4
+LABEL maintainer="Democracy Works, Inc. <dev@democracy.works>"
+
+ARG FLEETCTL_VERSION=0.11.8
+ARG KUBECTL_VERSION=1.9.2
+
+RUN apk add --no-cache \
+## Install OpenSSL
+    openssl \
+    openjdk8-jre \
+    "nodejs=8.14.0-r0" \
+    nodejs-npm \
+  && pip install \
+## Install AWS CLI
+     awscli \
+## Install leiningen
+  && curl -sSo /usr/local/bin/lein \
+     https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein \
+  && chmod +x /usr/local/bin/lein \
+  && /usr/local/bin/lein version \
+## Install kubectl
+  && curl -sSo /usr/local/bin/kubectl \
+     https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+  && chmod +x /usr/local/bin/kubectl \
+## Install fleetctl
+  && curl -sSLo /tmp/fleet.tar.gz \
+     https://github.com/coreos/fleet/releases/download/v${FLEETCTL_VERSION}/fleet-v${FLEETCTL_VERSION}-linux-amd64.tar.gz \
+  && tar -C /tmp -xzf /tmp/fleet.tar.gz \
+  && mv /tmp/fleet-v${FLEETCTL_VERSION}-linux-amd64/fleetctl /usr/local/bin/ \
+  && chmod +x /usr/local/bin/fleetctl \
+  && rm -rf /tmp/fleet*
+
+COPY hooks /buildkite/hooks
 
 COPY hooks/environment /buildkite/hooks/environment

--- a/README.md
+++ b/README.md
@@ -45,3 +45,23 @@ build script. Often this will be quay.io login and password.
 In addition to any project specific deploy env vars, you need to set up a
 `FLEETCTL_TUNNEL=<ip.address.node.in.cluster>`. This needs to point to the
 IP address of one of the nodes in the target cluster (staging or production).
+
+
+## Upgrade Notes
+
+The project maintaining the base image was archived, so I moved the contents
+of the Dockerfile over here and changed the base to the latest from buildkite
+and incorporated the necessary additions (leiningen and node). These allow
+an app that needs a lein plugin (such as cljs-lambda) to deploy via a script
+instead of needing to build and run a docker container just to deploy. This
+simplified deploy process was much easier to work with to get certain deploys
+working. And there is precedence for incorporating leiningen into our
+buildkite agents over on the other project space.
+
+There is a backwards incompatibility here that will require some minor modifications
+to the build scripts for existing projects that build and push up a docker image.
+The `docker login` command no longer allows the `-e=` command line option, but we
+weren't really doing anything with it anyway. It appears that it may have fallen out
+of use several docker versions back, but only in the 18.X series did the inclusion
+of it actually cause the command to break. So we just need to update the build
+scripts to remove this option from the docker login command.


### PR DESCRIPTION
…d processes

[Pivotal Card](https://www.pivotaltracker.com/story/show/161324736)

In order to accomodate the build process for the Alexa apps, I needed to do some upgrades to the buildkite agents. Also, since the DW project these agents were built off of was archived, I just moved the contents of it's Dockerfile here and made upgrades as needed. This also has the benefit of upgrading docker to the latest, but the downside then is that a deprecated command line option on the `docker login` commands our build scripts use is no longer valid and breaks the build, so we'll ultimately need to upgrade all the projects when we deploy this.